### PR TITLE
add path to deletion cookie

### DIFF
--- a/actix-session/src/lib.rs
+++ b/actix-session/src/lib.rs
@@ -495,6 +495,7 @@ pub mod test_helpers {
                 .find(|c| c.name() == "test-session")
                 .unwrap();
             assert_eq!(0, cookie_3.max_age().map(|t| t.whole_seconds()).unwrap());
+            assert_eq!("/", cookie_3.path().unwrap());
 
             // Step 10: GET index, including session cookie #3 in request
             //   - set-cookie actix-session should NOT be in response if invalidation is supported

--- a/actix-session/src/middleware.rs
+++ b/actix-session/src/middleware.rs
@@ -588,6 +588,7 @@ fn delete_session_cookie(
 ) -> Result<(), anyhow::Error> {
     let removal_cookie = Cookie::build(config.name.clone(), "")
         .path(config.path.clone())
+        .http_only(config.http_only)
         .max_age(time::Duration::seconds(0));
     let removal_cookie = if let Some(domain) = config.domain.clone() {
         removal_cookie.domain(domain).finish()

--- a/actix-session/src/middleware.rs
+++ b/actix-session/src/middleware.rs
@@ -584,6 +584,7 @@ fn delete_session_cookie(
     config: &CookieConfiguration,
 ) -> Result<(), anyhow::Error> {
     let removal_cookie = Cookie::build(config.name.clone(), "")
+        .path(config.path.clone())
         .max_age(time::Duration::seconds(0))
         .finish();
     let val = HeaderValue::from_str(&removal_cookie.to_string())

--- a/actix-session/tests/middleware.rs
+++ b/actix-session/tests/middleware.rs
@@ -36,6 +36,7 @@ async fn cookie_storage() -> std::io::Result<()> {
     assert_eq!(session_cookie.name(), "id");
     assert_eq!(session_cookie.path().unwrap(), "/test");
     assert_eq!(session_cookie.secure().unwrap(), true);
+    assert_eq!(session_cookie.http_only().unwrap(), true);
     assert!(session_cookie.max_age().is_none());
     assert_eq!(session_cookie.domain().unwrap(), "localhost");
 
@@ -48,6 +49,7 @@ async fn cookie_storage() -> std::io::Result<()> {
     assert_eq!(deletion_cookie.name(), "id");
     assert_eq!(deletion_cookie.path().unwrap(), "/test");
     assert!(deletion_cookie.secure().is_none());
+    assert_eq!(deletion_cookie.http_only().unwrap(), true);
     assert_eq!(deletion_cookie.max_age().unwrap(), Duration::ZERO);
     assert_eq!(deletion_cookie.domain().unwrap(), "localhost");
     Ok(())

--- a/actix-session/tests/middleware.rs
+++ b/actix-session/tests/middleware.rs
@@ -1,36 +1,35 @@
-use actix_session::{storage::CookieSessionStore, SessionMiddleware, Session};
-use actix_web::{App, web, cookie::{time::Duration, Key}, Responder, test};
+use actix_session::{storage::CookieSessionStore, Session, SessionMiddleware};
+use actix_web::{
+    cookie::{time::Duration, Key},
+    test, web, App, Responder,
+};
 
-
-async fn login(
-    session: Session,
-) -> impl Responder {
-	session.insert("user_id", "id").unwrap();
+async fn login(session: Session) -> impl Responder {
+    session.insert("user_id", "id").unwrap();
     "Logged in"
 }
 
-async fn logout(
-    session: Session,
-) -> impl Responder {
-	session.purge();
+async fn logout(session: Session) -> impl Responder {
+    session.purge();
     "Logged out"
 }
 
 #[actix_web::test]
 async fn cookie_storage() -> std::io::Result<()> {
     let signing_key = Key::generate();
-	let app = test::init_service(
-	        App::new()
-	            .wrap(
-	                SessionMiddleware::builder(
-	                    CookieSessionStore::default(),
-	                    signing_key.clone(),
-	                ).cookie_path("/test".to_string()).cookie_domain(Some("localhost".to_string())).build()
-	            )
-	            .route("/login", web::post().to(login))
-	            .route("/logout", web::post().to(logout))
-	    ).await;
-    
+    let app = test::init_service(
+        App::new()
+            .wrap(
+                SessionMiddleware::builder(CookieSessionStore::default(), signing_key.clone())
+                    .cookie_path("/test".to_string())
+                    .cookie_domain(Some("localhost".to_string()))
+                    .build(),
+            )
+            .route("/login", web::post().to(login))
+            .route("/logout", web::post().to(logout)),
+    )
+    .await;
+
     let login_request = test::TestRequest::post().uri("/login").to_request();
     let login_response = test::call_service(&app, login_request).await;
     let session_cookie = login_response.response().cookies().next().unwrap();
@@ -40,7 +39,10 @@ async fn cookie_storage() -> std::io::Result<()> {
     assert_eq!(session_cookie.max_age(), None);
     assert_eq!(session_cookie.domain(), None);
 
-    let logout_request = test::TestRequest::post().cookie(session_cookie).uri("/logout").to_request();
+    let logout_request = test::TestRequest::post()
+        .cookie(session_cookie)
+        .uri("/logout")
+        .to_request();
     let logout_response = test::call_service(&app, logout_request).await;
     let deletion_cookie = logout_response.response().cookies().next().unwrap();
     assert_eq!(deletion_cookie.name(), "id");

--- a/actix-session/tests/middleware.rs
+++ b/actix-session/tests/middleware.rs
@@ -34,10 +34,10 @@ async fn cookie_storage() -> std::io::Result<()> {
     let login_response = test::call_service(&app, login_request).await;
     let session_cookie = login_response.response().cookies().next().unwrap();
     assert_eq!(session_cookie.name(), "id");
-    assert_eq!(session_cookie.path(), Some("/test"));
-    assert_eq!(session_cookie.secure(), Some(true));
-    assert_eq!(session_cookie.max_age(), None);
-    assert_eq!(session_cookie.domain(), None);
+    assert_eq!(session_cookie.path().unwrap(), "/test");
+    assert_eq!(session_cookie.secure().unwrap(), true);
+    assert!(session_cookie.max_age().is_none());
+    assert_eq!(session_cookie.domain().unwrap(), "localhost");
 
     let logout_request = test::TestRequest::post()
         .cookie(session_cookie)
@@ -46,9 +46,9 @@ async fn cookie_storage() -> std::io::Result<()> {
     let logout_response = test::call_service(&app, logout_request).await;
     let deletion_cookie = logout_response.response().cookies().next().unwrap();
     assert_eq!(deletion_cookie.name(), "id");
-    assert_eq!(deletion_cookie.path(), Some("/test"));
-    assert_eq!(deletion_cookie.secure(), None);
-    assert_eq!(deletion_cookie.max_age(), Some(Duration::seconds(0)));
-    assert_eq!(deletion_cookie.domain(), None);
+    assert_eq!(deletion_cookie.path().unwrap(), "/test");
+    assert!(deletion_cookie.secure().is_none());
+    assert_eq!(deletion_cookie.max_age().unwrap(), Duration::ZERO);
+    assert_eq!(deletion_cookie.domain().unwrap(), "localhost");
     Ok(())
 }

--- a/actix-session/tests/middleware.rs
+++ b/actix-session/tests/middleware.rs
@@ -1,0 +1,50 @@
+use actix_session::{storage::CookieSessionStore, SessionMiddleware, Session};
+use actix_web::{App, web, cookie::{time::Duration, Key}, Responder, test};
+
+
+async fn login(
+    session: Session,
+) -> impl Responder {
+	session.insert("user_id", "id").unwrap();
+    "Logged in"
+}
+
+async fn logout(
+    session: Session,
+) -> impl Responder {
+	session.purge();
+    "Logged out"
+}
+
+#[actix_web::test]
+async fn cookie_storage() -> std::io::Result<()> {
+    let signing_key = Key::generate();
+	let app = test::init_service(
+	        App::new()
+	            .wrap(
+	                SessionMiddleware::new(
+	                    CookieSessionStore::default(),
+	                    signing_key.clone(),
+	                )
+	            )
+	            .route("/login", web::post().to(login))
+	            .route("/logout", web::post().to(logout))
+	    ).await;
+    
+    let login_request = test::TestRequest::post().uri("/login").to_request();
+    let login_response = test::call_service(&app, login_request).await;
+    let session_cookie = login_response.response().cookies().next().unwrap();
+    assert_eq!(session_cookie.name(), "id");
+    assert_eq!(session_cookie.path(), Some("/"));
+    assert_eq!(session_cookie.secure(), Some(true));
+    assert_eq!(session_cookie.max_age(), None);
+
+    let logout_request = test::TestRequest::post().cookie(session_cookie).uri("/logout").to_request();
+    let logout_response = test::call_service(&app, logout_request).await;
+    let deletion_cookie = logout_response.response().cookies().next().unwrap();
+    assert_eq!(deletion_cookie.name(), "id");
+    assert_eq!(deletion_cookie.path(), Some("/"));
+    assert_eq!(deletion_cookie.secure(), None);
+    assert_eq!(deletion_cookie.max_age(), Some(Duration::seconds(0)));
+    Ok(())
+}


### PR DESCRIPTION
Hi again @LukeMathWalker,

In the same way as https://github.com/LukeMathWalker/actix-web-flash-messages/pull/2, I had some issues with cookies not being deleted when using `session.purge()`, and it looks like it has to do with the path of the deletion cookie not matching the path of the original session cookie. Let me know if you want me to add in a test!